### PR TITLE
Feature #7102: adding a parameter into Attachment.properties in order to enable or not the use of file metadata for attachment data (title & description).

### DIFF
--- a/config-core/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
+++ b/config-core/src/main/config/properties/org/silverpeas/util/attachment/Attachment.properties
@@ -88,3 +88,7 @@ attachment.onlineEditing.customProtocol = false
 # Turn off this parameter if you don't want a popin alerts user to download and install
 # the necessary external program
 attachment.onlineEditing.customProtocol.alert = true
+
+# Turn on this parameter if metadata of a file must be used to fill data (title & description) of
+# an attachment. By default metadata are not used.
+attachment.data.fromMetadata = false

--- a/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
@@ -23,18 +23,17 @@
  */
 package org.silverpeas.attachment.util;
 
-import org.silverpeas.util.SettingBundle;
-import org.silverpeas.util.StringUtil;
 import org.silverpeas.util.ResourceLocator;
+import org.silverpeas.util.SettingBundle;
 
 /**
  * Handled the settings around the attachments.
- * @author: Yohann Chastagnier
+ * @author Yohann Chastagnier
  */
 public class AttachmentSettings {
 
-  private static ResourceLocator settings =
-      new ResourceLocator("org.silverpeas.util.attachment.Attachment", "");
+  private static SettingBundle settings =
+      ResourceLocator.getSettingBundle("org.silverpeas.util.attachment.Attachment");
 
   /**
    * Indicates if metadata of a file, if any, can be used to fill data (title & description) of an

--- a/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
+++ b/lib-core/src/main/java/org/silverpeas/attachment/util/AttachmentSettings.java
@@ -27,55 +27,21 @@ import org.silverpeas.util.SettingBundle;
 import org.silverpeas.util.StringUtil;
 import org.silverpeas.util.ResourceLocator;
 
-import javax.inject.Inject;
-
 /**
- * The aim of this class is to expose at the rest of application the settings around attachments.
- * Its implementation allows to manage the attachment parameters easily into unit tests. It assures
- * also less problems around setting regressions.
+ * Handled the settings around the attachments.
  * @author: Yohann Chastagnier
  */
 public class AttachmentSettings {
 
-  private static final AttachmentSettings instance = new AttachmentSettings();
+  private static ResourceLocator settings =
+      new ResourceLocator("org.silverpeas.util.attachment.Attachment", "");
 
   /**
-   * Indicates if obsolete wysiwyg content must be ignored.
-   * This method returns always false if {@link #getObsoleteWysiwygContentIgnoredMark()} returns
-   * a not defined value.
-   * False by default (attachment.wysiwyg.content.inspection.obsolete.ignore).
-   * @return true if wysiwyg content must be ignored, false otherwise.
+   * Indicates if metadata of a file, if any, can be used to fill data (title & description) of an
+   * attachment. (defined in properties by attachment.data.fromMetadata)
+   * @return true if they must be used, false otherwise.
    */
-  public static boolean isObsoleteWysiwygContentIgnored() {
-    return getInstance().getSettingBundle()
-        .getBoolean("attachment.wysiwyg.content.inspection.obsolete.ignore", false) &&
-        StringUtil.isDefined(getObsoleteWysiwygContentIgnoredMark());
+  public static boolean isUseFileMetadataForAttachmentDataEnabled() {
+    return settings.getBoolean("attachment.data.fromMetadata", false);
   }
-
-  /**
-   * Gets the strict mark to fill at start of a wysiwyg file to mark it as ignored.
-   * If the mark exists into the file, but not at beginning, it is not taken into account.
-   * (defined in properties by attachment.wysiwyg.content.inspection.obsolete.ignore.mark)
-   * @return the mark if defined, empty string otherwise.
-   */
-  public static String getObsoleteWysiwygContentIgnoredMark() {
-    return getInstance().getSettingBundle()
-        .getString("attachment.wysiwyg.content.inspection.obsolete.ignore.mark", "");
-  }
-
-  /**
-   * Gets the provider.
-   * @return
-   */
-  private SettingBundle getSettingBundle() {
-    return ResourceLocator.getSettingBundle("org.silverpeas.util.attachment.Attachment");
-  }
-
-  /**
-   * @return a AttachmentSettings instance.
-   */
-  public static AttachmentSettings getInstance() {
-    return instance;
-  }
-
 }

--- a/lib-core/src/main/java/org/silverpeas/media/video/ffmpeg/FFmpegThumbnailExtractor.java
+++ b/lib-core/src/main/java/org/silverpeas/media/video/ffmpeg/FFmpegThumbnailExtractor.java
@@ -30,7 +30,6 @@ import org.silverpeas.util.MetaData;
 import org.silverpeas.util.MetadataExtractor;
 import org.silverpeas.util.time.TimeData;
 
-import javax.inject.Inject;
 import java.io.File;
 
 /**
@@ -38,9 +37,6 @@ import java.io.File;
  * @author ebonnet
  */
 public class FFmpegThumbnailExtractor implements VideoThumbnailExtractor {
-
-  @Inject
-  private MetadataExtractor metadataExtractor;
 
   @Override
   public boolean isActivated() {
@@ -50,7 +46,7 @@ public class FFmpegThumbnailExtractor implements VideoThumbnailExtractor {
   @Override
   public void generateThumbnailsFrom(File video) {
     if (video.exists() && video.isFile()) {
-      MetaData metadata = metadataExtractor.extractMetadata(video);
+      MetaData metadata = MetadataExtractor.get().extractMetadata(video);
       TimeData timeData = metadata.getDuration();
       if (timeData != null) {
         File thumbnailDir = video.getParentFile();

--- a/lib-core/src/main/java/org/silverpeas/upload/UploadedFile.java
+++ b/lib-core/src/main/java/org/silverpeas/upload/UploadedFile.java
@@ -179,24 +179,19 @@ public class UploadedFile {
     String lang = I18NHelper.checkLanguage(contributionLanguage);
 
     // Title and description
-    String title = getTitle();
-    String description = getDescription();
-    if (!StringUtil.isDefined(title)) {
+    String title = defaultStringIfNotDefined(getTitle());
+    String description = defaultStringIfNotDefined(getDescription());
+    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+        !StringUtil.isDefined(title)) {
       MetadataExtractor extractor = ServiceProvider.getService(MetadataExtractor.class);
       MetaData metadata = extractor.extractMetadata(getFile());
       if (StringUtil.isDefined(metadata.getTitle())) {
         title = metadata.getTitle();
-      } else {
-        title = "";
       }
       if (!StringUtil.isDefined(description) && StringUtil.isDefined(metadata.getSubject())) {
         description = metadata.getSubject();
       }
     }
-    if (!StringUtil.isDefined(description)) {
-      description = "";
-    }
-
     // Simple document PK
     SimpleDocumentPK pk = new SimpleDocumentPK(null, resourcePk);
 

--- a/lib-core/src/main/java/org/silverpeas/upload/UploadedFile.java
+++ b/lib-core/src/main/java/org/silverpeas/upload/UploadedFile.java
@@ -28,18 +28,20 @@ import org.silverpeas.attachment.AttachmentServiceProvider;
 import org.silverpeas.attachment.model.SimpleAttachment;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.util.DateUtil;
 import org.silverpeas.util.FileRepositoryManager;
 import org.silverpeas.util.FileUtil;
 import org.silverpeas.util.MetaData;
 import org.silverpeas.util.MetadataExtractor;
-import org.silverpeas.util.ServiceProvider;
 import org.silverpeas.util.StringUtil;
 import org.silverpeas.util.WAPrimaryKey;
 import org.silverpeas.util.i18n.I18NHelper;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
+
+import static org.silverpeas.util.StringUtil.defaultStringIfNotDefined;
 
 /**
  * Representation of an uploaded file.<br/>
@@ -183,7 +185,7 @@ public class UploadedFile {
     String description = defaultStringIfNotDefined(getDescription());
     if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
         !StringUtil.isDefined(title)) {
-      MetadataExtractor extractor = ServiceProvider.getService(MetadataExtractor.class);
+      MetadataExtractor extractor = MetadataExtractor.get();
       MetaData metadata = extractor.extractMetadata(getFile());
       if (StringUtil.isDefined(metadata.getTitle())) {
         title = metadata.getTitle();

--- a/lib-core/src/main/java/org/silverpeas/util/MetadataExtractor.java
+++ b/lib-core/src/main/java/org/silverpeas/util/MetadataExtractor.java
@@ -42,6 +42,10 @@ import java.util.Set;
  */
 public class MetadataExtractor {
 
+  public static MetadataExtractor get() {
+    return ServiceProvider.getService(MetadataExtractor.class);
+  }
+
   private static Set<MediaType> mp4ParserSupportedTypes =
       new MP4Parser().getSupportedTypes(new ParseContext());
 

--- a/lib-core/src/test/java/org/silverpeas/util/MetadataExtractorTest.java
+++ b/lib-core/src/test/java/org/silverpeas/util/MetadataExtractorTest.java
@@ -23,11 +23,13 @@
  */
 package org.silverpeas.util;
 
+import org.apache.tika.Tika;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.silverpeas.media.Definition;
 import org.silverpeas.test.rule.CommonAPI4Test;
+import org.silverpeas.test.rule.MockByReflectionRule;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -42,6 +44,8 @@ import static org.junit.Assert.assertThat;
  */
 public class MetadataExtractorTest {
 
+  private final static Tika tika = new Tika();
+
   private static final File docFile = getDocumentNamed("/Liste_ECCA.doc");
   private static final File docxFile = getDocumentNamed("/Test.docx");
   private static final File ooFile = getDocumentNamed("/LibreOffice.odt");
@@ -55,11 +59,15 @@ public class MetadataExtractorTest {
   @Rule
   public CommonAPI4Test commonAPI4Test = new CommonAPI4Test();
 
+  @Rule
+  public MockByReflectionRule reflectionRule = new MockByReflectionRule();
+
   private MetadataExtractor instance;
 
   @Before
   public void setup() {
     instance = new MetadataExtractor();
+    reflectionRule.setField(instance, tika, "tika");
   }
 
   /**

--- a/web-core/src/main/java/com/silverpeas/importExport/control/PublicationImportExport.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/PublicationImportExport.java
@@ -111,7 +111,7 @@ public class PublicationImportExport {
         MetaData metaData = null;
         if (settings.isPoiUsed()) {
           // extract title, subject and keywords
-          metaData = MetadataExtractor.getInstance().extractMetadata(file.getAbsolutePath());
+          metaData = MetadataExtractor.get().extractMetadata(file.getAbsolutePath());
           if (StringUtil.isDefined(metaData.getTitle())) {
             nomPub = metaData.getTitle();
           }
@@ -126,7 +126,7 @@ public class PublicationImportExport {
         if (settings.useFileDates()) {
           // extract creation and last modification dates
           if (metaData == null) {
-            metaData = MetadataExtractor.getInstance().extractMetadata(file.getAbsolutePath());
+            metaData = MetadataExtractor.get().extractMetadata(file.getAbsolutePath());
           }
           if (metaData.getCreationDate() != null) {
             creationDate = metaData.getCreationDate();
@@ -179,9 +179,5 @@ public class PublicationImportExport {
   public static List<PublicationDetail> getUnbalancedPublications(String componentId) {
     return new ArrayList<>(getPublicationBm().getOrphanPublications(
         new PublicationPK("useless", componentId)));
-  }
-
-  private static MetadataExtractor getMetadataExtractor() {
-    return ServiceProvider.getService(MetadataExtractor.class);
   }
 }

--- a/web-core/src/main/java/com/silverpeas/importExport/control/PublicationImportExport.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/PublicationImportExport.java
@@ -111,7 +111,7 @@ public class PublicationImportExport {
         MetaData metaData = null;
         if (settings.isPoiUsed()) {
           // extract title, subject and keywords
-          metaData = getMetadataExtractor().extractMetadata(file.getAbsolutePath());
+          metaData = MetadataExtractor.getInstance().extractMetadata(file.getAbsolutePath());
           if (StringUtil.isDefined(metaData.getTitle())) {
             nomPub = metaData.getTitle();
           }
@@ -126,7 +126,7 @@ public class PublicationImportExport {
         if (settings.useFileDates()) {
           // extract creation and last modification dates
           if (metaData == null) {
-            metaData = getMetadataExtractor().extractMetadata(file.getAbsolutePath());
+            metaData = MetadataExtractor.getInstance().extractMetadata(file.getAbsolutePath());
           }
           if (metaData.getCreationDate() != null) {
             creationDate = metaData.getCreationDate();

--- a/web-core/src/main/java/com/silverpeas/importExport/control/PublicationsTypeManager.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/PublicationsTypeManager.java
@@ -54,6 +54,7 @@ import org.apache.commons.io.FileUtils;
 import org.silverpeas.attachment.AttachmentServiceProvider;
 import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.core.admin.OrganizationControllerProvider;
 import org.silverpeas.importExport.attachment.AttachmentDetail;
 import org.silverpeas.importExport.attachment.AttachmentImportExport;
@@ -90,8 +91,6 @@ import static java.io.File.separator;
  */
 public class PublicationsTypeManager {
 
-  @Inject
-  private MetadataExtractor metadataExtractor;
   @Inject
   private CoordinateImportExport coordinateImportExport;
   @Inject
@@ -748,7 +747,7 @@ public class PublicationsTypeManager {
                     if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
                         settings.isPoiUsed()) {
                       // extract title, subject and keywords
-                      metaData = MetadataExtractor.getInstance()
+                      metaData = MetadataExtractor.get()
                           .extractMetadata(attdetail.getAttachmentPath());
                       if (!StringUtil.isDefined(attdetail.getTitle()) &&
                           StringUtil.isDefined(metaData.getTitle())) {
@@ -763,7 +762,7 @@ public class PublicationsTypeManager {
                         settings.useFileDates()) {
                       // extract creation date
                       if (metaData == null) {
-                        metaData = MetadataExtractor.getInstance()
+                        metaData = MetadataExtractor.get()
                             .extractMetadata(attdetail.getAttachmentPath());
                       }
                       if (metaData.getCreationDate() != null) {

--- a/web-core/src/main/java/com/silverpeas/importExport/control/PublicationsTypeManager.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/PublicationsTypeManager.java
@@ -745,9 +745,11 @@ public class PublicationsTypeManager {
                     unitReport.setError(UnitReport.ERROR_FILE_SIZE_EXCEEDS_LIMIT);
                   } else {
                     MetaData metaData = null;
-                    if (settings.isPoiUsed()) {
+                    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+                        settings.isPoiUsed()) {
                       // extract title, subject and keywords
-                      metaData = metadataExtractor.extractMetadata(attdetail.getAttachmentPath());
+                      metaData = MetadataExtractor.getInstance()
+                          .extractMetadata(attdetail.getAttachmentPath());
                       if (!StringUtil.isDefined(attdetail.getTitle()) &&
                           StringUtil.isDefined(metaData.getTitle())) {
                         attdetail.setTitle(metaData.getTitle());
@@ -757,10 +759,12 @@ public class PublicationsTypeManager {
                         attdetail.setInfo(metaData.getSubject());
                       }
                     }
-                    if (settings.useFileDates()) {
+                    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+                        settings.useFileDates()) {
                       // extract creation date
                       if (metaData == null) {
-                        metaData = metadataExtractor.extractMetadata(attdetail.getAttachmentPath());
+                        metaData = MetadataExtractor.getInstance()
+                            .extractMetadata(attdetail.getAttachmentPath());
                       }
                       if (metaData.getCreationDate() != null) {
                         attdetail.setCreationDate(metaData.getCreationDate());

--- a/web-core/src/main/java/com/silverpeas/importExport/control/RepositoriesTypeManager.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/RepositoriesTypeManager.java
@@ -314,9 +314,8 @@ public class RepositoriesTypeManager {
                 currentUser.getId(), creationDate, null));
       }
       document.setDocumentType(documentType);
+      setMetadata(document, file);
     }
-
-    setMetadata(document, file);
 
     if (needCreation) {
       boolean notifying = !document.isVersioned() || publicVersion;
@@ -348,10 +347,13 @@ public class RepositoriesTypeManager {
    * @param file the physical file.
    */
   private static void setMetadata(SimpleDocument document, File file) {
-    final MetaData metadata = getMetadataExtractor().extractMetadata(file);
-    document.setSize(file.length());
-    document.setTitle(metadata.getTitle());
-    document.setDescription(metadata.getSubject());
+    if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled()) {
+      final MetadataExtractor extractor = MetadataExtractor.getInstance();
+      final MetaData metadata = extractor.extractMetadata(file);
+      document.setSize(file.length());
+      document.setTitle(metadata.getTitle());
+      document.setDescription(metadata.getSubject());
+    }
   }
 
   private static MetadataExtractor getMetadataExtractor() {

--- a/web-core/src/main/java/com/silverpeas/importExport/control/RepositoriesTypeManager.java
+++ b/web-core/src/main/java/com/silverpeas/importExport/control/RepositoriesTypeManager.java
@@ -47,6 +47,7 @@ import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.attachment.model.UnlockContext;
 import org.silverpeas.attachment.model.UnlockOption;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.core.admin.OrganizationControllerProvider;
 import org.silverpeas.importExport.attachment.AttachmentDetail;
 import org.silverpeas.importExport.attachment.AttachmentImportExport;
@@ -59,7 +60,6 @@ import org.silverpeas.util.FileUtil;
 import org.silverpeas.util.ForeignPK;
 import org.silverpeas.util.MetaData;
 import org.silverpeas.util.MetadataExtractor;
-import org.silverpeas.util.ServiceProvider;
 import org.silverpeas.util.StringUtil;
 import org.silverpeas.util.error.SilverpeasTransverseErrorUtil;
 import org.silverpeas.util.i18n.I18NHelper;
@@ -348,16 +348,12 @@ public class RepositoriesTypeManager {
    */
   private static void setMetadata(SimpleDocument document, File file) {
     if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled()) {
-      final MetadataExtractor extractor = MetadataExtractor.getInstance();
+      final MetadataExtractor extractor = MetadataExtractor.get();
       final MetaData metadata = extractor.extractMetadata(file);
       document.setSize(file.length());
       document.setTitle(metadata.getTitle());
       document.setDescription(metadata.getSubject());
     }
-  }
-
-  private static MetadataExtractor getMetadataExtractor() {
-    return ServiceProvider.getService(MetadataExtractor.class);
   }
 
   private void processMailContent(PublicationDetail pubDetail, File file,

--- a/web-core/src/main/java/org/silverpeas/attachment/web/SimpleDocumentResourceCreator.java
+++ b/web-core/src/main/java/org/silverpeas/attachment/web/SimpleDocumentResourceCreator.java
@@ -42,6 +42,7 @@ import org.silverpeas.attachment.model.SimpleDocument;
 import org.silverpeas.attachment.model.SimpleDocumentPK;
 import org.silverpeas.attachment.model.UnlockContext;
 import org.silverpeas.attachment.model.UnlockOption;
+import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.importExport.versioning.DocumentVersion;
 import org.silverpeas.servlet.RequestParameterDecoder;
 
@@ -61,6 +62,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Date;
 
+import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
 import static org.silverpeas.web.util.IFrameAjaxTransportUtil.*;
 
 /**
@@ -140,21 +142,17 @@ public class SimpleDocumentResourceCreator extends AbstractSimpleDocumentResourc
         checkUploadedFile(tempFile);
 
         String lang = I18NHelper.checkLanguage(uploadData.getLanguage());
-        String title = uploadData.getTitle();
-        String description = uploadData.getDescription();
-        if (!StringUtil.isDefined(title)) {
+        String title = defaultStringIfNotDefined(uploadData.getTitle());
+        String description = defaultStringIfNotDefined(uploadData.getDescription());
+        if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
+            !StringUtil.isDefined(title)) {
           MetaData metadata = metadataExtractor.extractMetadata(tempFile);
           if (StringUtil.isDefined(metadata.getTitle())) {
             title = metadata.getTitle();
-          } else {
-            title = "";
           }
           if (!StringUtil.isDefined(description) && StringUtil.isDefined(metadata.getSubject())) {
             description = metadata.getSubject();
           }
-        }
-        if (!StringUtil.isDefined(description)) {
-          description = "";
         }
 
         DocumentType attachmentContext;

--- a/web-core/src/main/java/org/silverpeas/attachment/web/SimpleDocumentResourceCreator.java
+++ b/web-core/src/main/java/org/silverpeas/attachment/web/SimpleDocumentResourceCreator.java
@@ -46,7 +46,6 @@ import org.silverpeas.attachment.util.AttachmentSettings;
 import org.silverpeas.importExport.versioning.DocumentVersion;
 import org.silverpeas.servlet.RequestParameterDecoder;
 
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -62,7 +61,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Date;
 
-import static com.silverpeas.util.StringUtil.defaultStringIfNotDefined;
+import static org.silverpeas.util.StringUtil.defaultStringIfNotDefined;
 import static org.silverpeas.web.util.IFrameAjaxTransportUtil.*;
 
 /**
@@ -73,9 +72,6 @@ import static org.silverpeas.web.util.IFrameAjaxTransportUtil.*;
 @Path("documents/{componentId}/document/create")
 @Authorized
 public class SimpleDocumentResourceCreator extends AbstractSimpleDocumentResource {
-
-  @Inject
-  private MetadataExtractor metadataExtractor;
 
   /**
    * Create the document identified by the requested URI and from the content and some additional
@@ -146,7 +142,8 @@ public class SimpleDocumentResourceCreator extends AbstractSimpleDocumentResourc
         String description = defaultStringIfNotDefined(uploadData.getDescription());
         if (AttachmentSettings.isUseFileMetadataForAttachmentDataEnabled() &&
             !StringUtil.isDefined(title)) {
-          MetaData metadata = metadataExtractor.extractMetadata(tempFile);
+          MetadataExtractor extractor = MetadataExtractor.get();
+          MetaData metadata = extractor.extractMetadata(tempFile);
           if (StringUtil.isDefined(metadata.getTitle())) {
             title = metadata.getTitle();
           }


### PR DESCRIPTION
Migration from 5.15

Linked to https://github.com/SilverTeamWork/Silverpeas-Components/pull/6
